### PR TITLE
Add mechanism for installing without neutron and felix

### DIFF
--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -19,6 +19,7 @@ class calico::compute (
   $peer_template           = $calico::compute_peer_template,
   $peers                   = {},
   $router_id               = $calico::router_id,
+  $openstack_computehost   = $calico::compute_openstack_computehost,
 ) {
 
   validate_bool($felix_enable)
@@ -51,10 +52,12 @@ class calico::compute (
     enable => $felix_enable,
   }
 
-  Class['neutron'] ->
-  Package[$calico::compute_package] ->
-  File[$calico::felix_conf] ~>
-  Service[$calico::felix_service]
+  if $openstack_computehost {
+    Class['neutron'] ->
+    Package[$calico::compute_package] ->
+    File[$calico::felix_conf] ~>
+    Service[$calico::felix_service]
+  }
 
   if $manage_metadata_service {
     package { $calico::compute_metadata_package:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@
 # Default parameter values
 #
 class calico::params {
+  $compute_openstack_computehost    = true
   $compute_bird_template            = 'calico/compute/bird.conf.erb'
   $compute_bird6_template           = 'calico/compute/bird6.conf.erb'
   $compute_etcd_host                = '127.0.0.1'


### PR DESCRIPTION
While the module has nice parameters to disable the management of several services, the module will fail if neutron and felix are absent. However, there are use cases where this dependency isn't wanted.
