### PR TITLE
Add ability to point to other then default templates for bird.conf

### DIFF
--- a/manifests/bird.pp
+++ b/manifests/bird.pp
@@ -11,11 +11,11 @@ class calico::bird {
 
   # Select bird config templates according to enabled role
   if $calico::compute_manage_bird_config {
-    $bird_template  = $calico::compute_bird_template
-    $bird6_template = $calico::compute_bird6_template
+    $bird_template  = $calico::compute::bird_template
+    $bird6_template = $calico::compute::bird6_template
   } elsif $calico::reflector_manage_bird_config {
-    $bird_template  = $calico::reflector_bird_template
-    $bird6_template = $calico::reflector_bird6_template
+    $bird_template  = $calico::reflector::bird_template
+    $bird6_template = $calico::reflector::bird6_template
   }
 
   # Manage bird.conf and bird6.conf

--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -2,6 +2,7 @@
 #
 class calico::compute (
   $bird_template           = $calico::compute_bird_template,
+  $bird6_template           = $calico::compute_bird6_template,
   $compute_package         = $calico::compute_package,
   $compute_package_ensure  = $calico::compute_package_ensure,
   $etcd_host               = $calico::compute_etcd_host,

--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -2,7 +2,7 @@
 #
 class calico::compute (
   $bird_template           = $calico::compute_bird_template,
-  $bird6_template           = $calico::compute_bird6_template,
+  $bird6_template          = $calico::compute_bird6_template,
   $compute_package         = $calico::compute_package,
   $compute_package_ensure  = $calico::compute_package_ensure,
   $etcd_host               = $calico::compute_etcd_host,

--- a/manifests/reflector.pp
+++ b/manifests/reflector.pp
@@ -2,7 +2,7 @@
 #
 class calico::reflector (
   $bird_template           = $calico::reflector_bird_template,
-  $bird6_template           = $calico::reflector_bird6_template,
+  $bird6_template          = $calico::reflector_bird6_template,
   $manage_bird_config      = $calico::reflector_manage_bird_config,
   $manage_clients          = $calico::reflector_manage_clients,
   $client_defaults         = {},

--- a/manifests/reflector.pp
+++ b/manifests/reflector.pp
@@ -2,6 +2,7 @@
 #
 class calico::reflector (
   $bird_template           = $calico::reflector_bird_template,
+  $bird6_template           = $calico::reflector_bird6_template,
   $manage_bird_config      = $calico::reflector_manage_bird_config,
   $manage_clients          = $calico::reflector_manage_clients,
   $client_defaults         = {},


### PR DESCRIPTION
It seems like the module creator added an ability to change template location for bird(6).conf. Alas, this doesn't work. These changes fixes this.
