### PR TITLE
Added input param for management of bird for compute and reflector

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,8 @@ class calico (
   $enable_ipv6 = $calico::params::enable_ipv6,
   $reflector   = false,
   $debug       = false,
+  $compute_manage_bird_config = $::calico::params::compute_manage_bird_config,
+  $reflector_manage_bird_config = $::calico::params::reflector_manage_bird_config
 ) inherits calico::params {
 
   validate_bool($compute)


### PR DESCRIPTION
This fixes #6

If you use hieradata like this reflector will still work:
`calico::compute_manage_bird_config: false`
`calico::reflector::bird_template:    'calico/compute/bird.conf.erb'`
`calico::reflector::bird6_template:   'calico/compute/bird6.conf.erb'`
