### PR TITLE
Enable management of calico-dhcp-agent

### DIFF
--- a/manifests/compute.pp
+++ b/manifests/compute.pp
@@ -68,6 +68,12 @@ class calico::compute (
         package { 'calico-dhcp-agent':
           ensure => installed,
         }
+        service { 'calico-dhcp-agent':
+          enable      => true,
+          ensure      => running,
+          hasrestart  => true,
+          hasstatus   => true,
+        }
       }
     }
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class calico::params {
   $compute_bird_template            = 'calico/compute/bird.conf.erb'
   $compute_bird6_template           = 'calico/compute/bird6.conf.erb'
+  $compute_dhcp_agent               = 'neutron'
   $compute_etcd_host                = '127.0.0.1'
   $compute_etcd_port                = '4001'
   $compute_manage_bird_config       = true


### PR DESCRIPTION
Starting with calico release 1.4, the neutron-dhcp-agent is replaced with calico-dhcp-agent, witch uses etcd for communications. These changes enables the use of the new dhcp agent by passing "calico" to compute_dhcp_agent.

The default behaviour of  the module is not changed.
